### PR TITLE
Added basic custom post type and back-end api functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .DS_Store
+.idea

--- a/back/class.styleguide.api.php
+++ b/back/class.styleguide.api.php
@@ -1,0 +1,186 @@
+<?php
+
+class Styleguide_Endpoints {
+
+	protected $post_type;
+
+	public function __construct() {
+		$this->post_type = 'styles';
+		$this->namespace = 'styles';
+	}
+
+	public function register_routes() {
+		register_rest_route( $this->namespace, '/style', array(
+			array(
+				'methods' 				=> WP_REST_Server::READABLE,
+				'callback' 				=> array( $this, 'get_items' ),
+				'permission_callback' 	=> array( $this, 'general_permissions_check' )
+			),
+			array( 
+				'methods' 				=> WP_REST_Server::CREATABLE,
+				'callback' 				=> array( $this, 'create_item' ),
+				'permission_callback' 	=> array( $this, 'general_permissions_check' )
+			)
+		));
+
+		register_rest_route( $this->namespace, '/style' . '/(?P<id>[\d]+)', array(
+			array(
+				'methods' 				=> WP_REST_Server::EDITABLE,
+				'callback' 				=> array( $this, 'update_item' ),
+				'permission_callback' 	=> array( $this, 'general_permissions_check' )
+			),
+			array( 
+				'methods' 				=> WP_REST_Server::DELETABLE,
+				'callback' 				=> array( $this, 'delete_item' ),
+				'permission_callback' 	=> array( $this, 'general_permissions_check' )
+			)
+		));
+	}
+
+	public function general_permissions_check( $request ) {
+		// TODO : SET UP PROPER PERMISSIONS CHECK
+		// if ( !current_user_can( $post_type->cap->edit_posts ) ) {
+		// 	return false;
+		// }
+
+		return true;
+	}
+
+	public function get_items( $request ) {
+		$styles_query = new WP_Query();
+
+		$query_result = $styles_query->query( array( 'post_type' => $this->post_type, 'posts_per_page' => -1 ) );
+
+		$posts = array();
+
+		foreach( $query_result as $result ) {
+			$data = $this->prepare_item_for_response( $result, $request );
+			$posts[] = $data;
+		}
+
+		$total = $styles_query->found_posts;
+
+		$response = rest_ensure_response( $posts );
+		$response->header( 'X-WP-Total', (int) $total );
+
+		return $response;
+	}
+
+	public function prepare_item_for_response( $post, $request ) {
+		setup_postdata( $post );
+
+		$data = array( 
+			'id' => $post->ID,
+			'slug' => $post->post_name,
+			'date' => $post->date,
+			'title' => get_the_title( $post->ID ),
+			'html' => $post->post_content,
+			'description' => apply_filters( 'the_content', $post->post_content ),
+		);
+
+		$response = rest_ensure_response( $data );
+
+		return $response;
+	}
+
+	public function create_item( $request ) {
+		if ( ! empty( $request['id'] ) ) {
+			return new WP_Error( 'rest_post_exists', __( 'Cannot create existing post.' ), array( 'status' => 400 ) );
+		}
+
+		$post = $this->prepare_item_for_database( $request );
+
+		$post->post_type = $this->post_type;
+		$post_id = wp_insert_post( $post, true );
+
+		if ( is_wp_error( $post_id ) ) {
+			if ( in_array( $post_id->get_error_code(), array( 'db_insert_error' ) ) ) {
+				$post_id->add_data( array( 'status' => 500 ) );
+			} else {
+				$post_id->add_data( array( 'status' => 400 ) );
+			}
+			return $post_id;
+		}
+
+		$post = get_post( $post_id );
+		$response = $this->prepare_item_for_response( $post, $request );
+		$response = rest_ensure_response( $response );
+		$response->set_status( 201 );
+		$response->header( 'Location', rest_url( sprintf( '/%s/%s/%d', $this->namespace, 'style', $post_id ) ) );
+		return $response;
+	}
+
+	public function update_item( $request ) {
+		$id = (int) $request['id'];
+		$post = get_post( $id );
+
+		if ( empty( $id ) || empty( $post->ID ) || $this->post_type !== $post->post_type ) {
+			return new WP_Error( 'rest_post_invalid_id', __( 'Post id is invalid.' ), array( 'status' => 400 ) );
+		}
+
+		$post = $this->prepare_item_for_database( $request );
+
+		$post_id = wp_update_post( (array) $post, true );
+		if ( is_wp_error( $post_id ) ) {
+			if ( in_array( $post_id->get_error_code(), array( 'db_update_error' ) ) ) {
+				$post_id->add_data( array( 'status' => 500 ) );
+			} else {
+				$post_id->add_data( array( 'status' => 400 ) );
+			}
+			return $post_id;
+		}
+
+		$response = $this->prepare_item_for_response( $post, $request );
+		return rest_ensure_response( $response );
+	}
+
+	public function delete_item( $request ) {
+		$id = (int) $request['id'];
+
+		$post = get_post( $id );
+		if ( empty( $id ) || empty( $post->ID ) || $this->post_type !== $post->post_type ) {
+			return new WP_Error( 'rest_post_invalid_id', __( 'Invalid post id.' ), array( 'status' => 404 ) );
+		}
+
+		$response = $this->prepare_item_for_response( $post, $request );
+		$result = wp_delete_post( $id, true );
+		
+		if ( ! $result ) {
+			return new WP_Error( 'rest_cannot_delete', __( 'The post cannot be deleted.' ), array( 'status' => 500 ) );
+		}
+
+		return $response;
+	}
+
+	public function prepare_item_for_database( $post ) {
+		$prepared_post = new stdClass;
+
+		if( isset( $request['id'] ) ) {
+			$prepared_post->ID = absint( $request['id'] );
+		}
+
+		if( isset( $request['title'] ) && is_string( $request['title'] ) ) {
+			$prepared_post->post_title = wp_filter_post_kses( $request['title'] );
+		}
+
+		if( isset( $request['html'] ) && is_string( $request['html'] ) ) {
+			$prepared_post->post_content = wp_filter_post_kses( $request['html'] );
+		}
+
+		$prepared_post->post_type = $this->post_type;
+
+		if ( ! empty( $request['date'] ) ) {
+			$date_data = rest_get_date_with_gmt( $request['date'] );
+			if ( ! empty( $date_data ) ) {
+				list( $prepared_post->post_date, $prepared_post->post_date_gmt ) = $date_data;
+			}
+		}
+
+		if ( isset( $request['slug'] ) ) {
+			$prepared_post->post_name = $request['slug'];
+		}
+
+		return $prepared_post;
+	}
+
+}

--- a/back/class.styleguide.data.php
+++ b/back/class.styleguide.data.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * Data class
+ *
+ * Sets up post type and any other data types needed by the API
+ *
+ * @since 0.0.1
+ */
+
+class Styleguide_Data {
+
+	static $instance = false;
+
+	/**
+	 * Initialize the class with a new instance
+	 *
+	 * @return bool|Styleguide_Data
+	 */
+	public static function init() {
+		if ( ! self::$instance ) {
+			self::$instance = new Styleguide_Data;
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Styleguide_Data constructor.
+	 */
+	public function __construct() {
+		add_action( 'init', array( $this, 'add_styles_posttype' ) );
+	}
+
+	/**
+	 * Register styles post type
+	 * - Used as the main data type for style components
+	 */
+	public function add_styles_posttype() {
+		register_post_type( 'styles', array(
+			'label' => 'STYLE',
+			// TODO: Set public to false and remove label
+			// This is only here to add data on the back-end while we're testing
+			'public' => true,
+			'supports' => array( 'title', 'editor', 'date' )
+		));
+	}
+
+}

--- a/back/class.styleguide.front.php
+++ b/back/class.styleguide.front.php
@@ -1,25 +1,22 @@
 <?php
 /**
-* Loader Class for front-end template and scripts
-*
-* Adds a simple front-end template which lets the client side take
-* take care of everything and enqueues the scripts needed
-* to get this thing to kick-off.
-*
-* @since 0.0.1
-*/
+ * Loader Class for front-end template and scripts
+ *
+ * Adds a simple front-end template which lets the client side take
+ * take care of everything and enqueues the scripts needed
+ * to get this thing to kick-off.
+ *
+ * @since 0.0.1
+ */
 
 class Styleguide_Front {
 
 	static $instance = false;
-	
+
 	/**
-	 * Initialize Class with a new instance
-	 * 
-	 * @since 0.0.1
-	 * 
-	 * @global boolean $instance
-	 * 
+	 * Initialize the class with a new instance
+	 *
+	 * @return bool|Styleguide_Front
 	 */
 	public static function init() {
 		if ( ! self::$instance ) {

--- a/back/class.styleguide.loader.php
+++ b/back/class.styleguide.loader.php
@@ -39,7 +39,9 @@ class Styleguide_Loader {
 	private function __construct() {
 		add_action('template_redirect', array( $this, 'load_styleguide_template') );
 		add_action( 'init', array( $this, 'handle_rewrites' ) );
-		//add_action('init', array( $this, 'load_rest_endpoints' ) );
+		add_action('rest_api_init', array( $this, 'load_rest_endpoints' ) );
+
+		Styleguide_Data::init();
 	}
 
 
@@ -58,6 +60,11 @@ class Styleguide_Loader {
 		if (isset($wp_query->query_vars['styleguide'])) {
 			Styleguide_Front::init();
 		}
+	}
+
+	public function load_rest_endpoints() {
+		$api = new Styleguide_Endpoints;
+		$api->register_routes();
 	}
 
 

--- a/wp-styleguide.php
+++ b/wp-styleguide.php
@@ -17,6 +17,8 @@ define( 'STYLEGUIDE__PLUGIN_BASE',         plugin_basename( __FILE__ ) );
 define( 'STYLEGUIDE__PLUGIN_FILE',        __FILE__ );
 
 require_once( STYLEGUIDE__PLUGIN_DIR . 'back/class.styleguide.front.php' );
+require_once( STYLEGUIDE__PLUGIN_DIR . 'back/class.styleguide.data.php' );
+require_once( STYLEGUIDE__PLUGIN_DIR . 'back/class.styleguide.api.php' );
 require_once( STYLEGUIDE__PLUGIN_DIR . 'back/class.styleguide.loader.php' );
 require_once( STYLEGUIDE__PLUGIN_DIR . 'back/class.styleguide.activate.php' );
 


### PR DESCRIPTION
@SolomonSScott Hey so I think we should submit all our changes as pull requests that the other person has to accept. That way, we're aware of the changes the other is working on. So here's my changes:

Added custom post type and basic API. The url for the API endpoint is '/wp-json/styles/style'. You can pull all style posts from this and post to it to add new. The data it returns is really basic right now and looks like:
- id
- slug
- date
- title
- html (unrendered html)
- description (rendered html)

One thing I haven't done yet is add a taxonomy so we can group together components into sections, but this is enough to get some really basic Vue app up. I'll start working on that part. Check it out and let me know what you think.
