### PR TITLE
Added in taxonomy for sections and outputted these to endpoints

### DIFF
--- a/back/class.styleguide.data.php
+++ b/back/class.styleguide.data.php
@@ -41,7 +41,13 @@ class Styleguide_Data {
 			// TODO: Set public to false and remove label
 			// This is only here to add data on the back-end while we're testing
 			'public' => true,
-			'supports' => array( 'title', 'editor', 'date' )
+			'supports' => array( 'title', 'editor', 'date' ),
+			'taxonomies' => array('style_sections')
+		));
+
+		register_taxonomy( 'style_sections', 'styles', array(
+			'label' => 'STYLE SECTIONS',
+			'public' => true
 		));
 	}
 


### PR DESCRIPTION
Created a taxonomy with the namespace "style_sections". This maps to two output fields in the API "section_name" and "section_slug". I made them two individual fields instead of a single object because Vue typically likes things to keep pretty flat.
